### PR TITLE
Add product and description page URLs to board descriptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,9 @@ Information related to the hardware including the hardware's name, description a
 | PID         | Yes      | int16     | USB Product ID                                          |
 | displayName | Yes      | String    | Adafruit IO Device name                                 |
 | description  | Yes      | String    | Device description                                       |
-| lastUpdated | Yes      | Time      | Last time the board description was updated, in ISO-8601 |
+| productPageURL | Yes      | String      | Link to board's homepage. |
+| documentationURL | Yes      | String      | Link to board's documentation. |
+
 
 ### boardName Naming Scheme
 A `boardName` MAY ONLY contain lower case ASCII letters, numbers, and the dash character (“-”).

--- a/definitions/adafruit-huzzah-32/definition.json
+++ b/definitions/adafruit-huzzah-32/definition.json
@@ -4,7 +4,8 @@
     "VID":"0x239A",
     "PID":"0x8036",
     "displayName":"Adafruit Feather HUZZAH ESP32",
-    "description":"Feather Huzzah with ESP32.",
+    "productPageURL":"https://www.adafruit.com/product/3405",
+    "documentationURL":"https://learn.adafruit.com/adafruit-huzzah32-esp32-feather",
     "components": {
       "digitalPins": [
        {

--- a/definitions/adafruit-huzzah-8266/definition.json
+++ b/definitions/adafruit-huzzah-8266/definition.json
@@ -5,6 +5,8 @@
     "PID":"0x10C4",
     "displayName": "Feather Huzzah ESP8266",
     "description": "Feather Huzzah ESP8266 with USB and Battery Charging.",
+    "productPageURL":"https://www.adafruit.com/product/2821",
+    "documentationURL":"https://learn.adafruit.com/adafruit-feather-huzzah-esp8266",
     "components": {
       "digitalPins": [
         {

--- a/definitions/adafruit-metro-m4-airliftlite/definition.json
+++ b/definitions/adafruit-metro-m4-airliftlite/definition.json
@@ -5,6 +5,8 @@
     "PID": "0x8038",
     "displayName": "Metro M4 Airlift Lite",
     "description": "Metro M4 + ESP32 Airlift Co-Processor.",
+    "productPageURL":"https://www.adafruit.com/product/4000",
+    "documentationURL":"https://learn.adafruit.com/adafruit-metro-m4-express-airlift-wifi",
     "components": {
       "digitalPins": [
         {

--- a/definitions/adafruit-metro-m4/definition.json
+++ b/definitions/adafruit-metro-m4/definition.json
@@ -4,7 +4,9 @@
     "VID": "0x239A",
     "PID": "0x8021",
     "displayName": "Metro M4 Express",
-    "description": "Metro M4 Express + ESP32 Airlift Shield.",
+    "description": "Metro M4 Express.",
+    "productPageURL":"https://www.adafruit.com/product/3382",
+    "documentationURL":"https://learn.adafruit.com/adafruit-metro-m4-express-featuring-atsamd51",
     "components": {
       "digitalPins": [
         {

--- a/definitions/adafruit-pyportal-m4/definition.json
+++ b/definitions/adafruit-pyportal-m4/definition.json
@@ -5,6 +5,8 @@
     "PID": "0x8036",
     "displayName": "PyPortal",
     "description": "320x240 IoT display.",
+    "productPageURL":"https://www.adafruit.com/product/4116",
+    "documentationURL":"https://learn.adafruit.com/adafruit-pyportal",
     "components":
     {
       "digitalPins": [

--- a/definitions/microchip-mcp2221/definition.json
+++ b/definitions/microchip-mcp2221/definition.json
@@ -5,6 +5,8 @@
     "PID": "0x00dd",
     "displayName": "MCP2221",
     "description": "General purpose USB to GPIO w/ADC, DAC, I2C.",
+    "productPageURL":"https://www.adafruit.com/product/4471",
+    "documentationURL":"https://learn.adafruit.com/circuitpython-libraries-on-any-computer-with-mcp2221",
     "components": {
       "digitalPins": [
         {


### PR DESCRIPTION
- Updates README.
- Adds URLs for product and description pages for all boards.

Addresses: https://github.com/adafruit/Wippersnapper_Boards/issues/5