### PR TITLE
Add i2cPorts to all boards

### DIFF
--- a/definitions/adafruit-funhouse-esp32s2/definition.json
+++ b/definitions/adafruit-funhouse-esp32s2/definition.json
@@ -123,33 +123,6 @@
                "SDA": 34,
                "SCL": 33
            }
-       ],
-       "i2cSensors":[
-          {
-             "name":"AHT20",
-             "displayName":"AHT20 Humidity and Temperature Sensor",
-             "address":"0x38",
-             "address2":null,
-             "sensorId":null,
-             "type":null,
-             "maxValue":null,
-             "minValue":null,
-             "resolution":null,
-             "minDelay":null
-          },
-          {
-             "name":"DPS310",
-             "displayName":"AHT20 Humidity and Temperature Sensor",
-             "address":"0x77",
-             "address2":null,
-             "sensorId":null,
-             "id":null,
-             "type":null,
-             "maxValue":null,
-             "minValue":null,
-             "resolution":null,
-             "minDelay":null
-          }
        ]
     }
  }

--- a/definitions/adafruit-huzzah-32/definition.json
+++ b/definitions/adafruit-huzzah-32/definition.json
@@ -131,6 +131,13 @@
           "displayName":"VBAT",
           "dataType":"int16"
        }
+      ],
+      "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 23,
+            "SCL": 22
+        }
       ]
     }
 }

--- a/definitions/adafruit-huzzah-8266/definition.json
+++ b/definitions/adafruit-huzzah-8266/definition.json
@@ -62,6 +62,13 @@
             "displayName": "A0",
             "dataType": "int16"
         }
+      ],
+      "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 4,
+            "SCL": 5
+        }
       ]
     }
 }

--- a/definitions/adafruit-magtag-esp32s2/definition.json
+++ b/definitions/adafruit-magtag-esp32s2/definition.json
@@ -56,6 +56,13 @@
              "displayName":"Light Sensor (A3)",
              "dataType":"int16"
           }
-       ]
+       ],
+       "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 33,
+            "SCL": 34
+        }
+      ]
     }
 }

--- a/definitions/adafruit-metro-esp32s2/definition.json
+++ b/definitions/adafruit-metro-esp32s2/definition.json
@@ -186,6 +186,13 @@
             "displayName":"A16 (IO16)",
             "dataType":"int16"
          }
-       ]
+       ],
+       "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 33,
+            "SCL": 34
+        }
+      ]
     }
  }

--- a/definitions/adafruit-metro-m4-airliftlite/definition.json
+++ b/definitions/adafruit-metro-m4-airliftlite/definition.json
@@ -112,6 +112,13 @@
             "displayName": "A5",
             "dataType": "int16"
         }
+      ],
+      "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 22,
+            "SCL": 23
+        }
       ]
     }
 }

--- a/definitions/adafruit-metro-m4/definition.json
+++ b/definitions/adafruit-metro-m4/definition.json
@@ -112,6 +112,13 @@
             "displayName": "A5",
             "dataType": "int16"
         }
+      ],
+      "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 22,
+            "SCL": 23
+        }
       ]
     }
 }

--- a/definitions/adafruit-pyportal-m4/definition.json
+++ b/definitions/adafruit-pyportal-m4/definition.json
@@ -44,13 +44,11 @@
             "dataType": "int16"
         }
       ],
-      "pixels": [
+      "i2cPorts": [
         {
-          "displayName": "Built-in NeoPixel",
-          "pixelPin": 1,
-          "pixelNumber": 1,
-          "pixelType": "PIXEL_TYPE_WS2812",
-          "pixelOrder": "PIXEL_ORDER_RGB"
+            "i2cPortId": "0",
+            "SDA": 27,
+            "SCL": 28
         }
       ]
     }

--- a/definitions/microchip-mcp2221/definition.json
+++ b/definitions/microchip-mcp2221/definition.json
@@ -50,6 +50,13 @@
             "dataType": "int",
             "max_resolution": 10
         }
+      ],
+      "i2cPorts": [
+        {
+            "i2cPortId": "0",
+            "SDA": 22,
+            "SCL": 23
+        }
       ]
     }
 }


### PR DESCRIPTION
* Adds `i2cPorts` for all supported hardware.
* Removes unused+deprecated arrays: `i2cSensors`,  `pixels`

cc @lorennorman 