### PR TITLE
Add ESP32 Feather v2 Push-button to definition

### DIFF
--- a/boards/feather-esp32-v2-daily/definition.json
+++ b/boards/feather-esp32-v2-daily/definition.json
@@ -87,6 +87,11 @@
         "name":"D37",
         "displayName":"D37",
         "dataType":"bool"
+       },
+       {
+        "name":"D38",
+        "displayName":"Button Switch (SW38)",
+        "dataType":"bool"
        }
       ],
       "analogPins": [

--- a/boards/feather-esp32-v2-daily/definition.json
+++ b/boards/feather-esp32-v2-daily/definition.json
@@ -91,7 +91,8 @@
        {
         "name":"D38",
         "displayName":"Button Switch (SW38)",
-        "dataType":"bool"
+        "dataType":"bool",
+        "direction": 0
        }
       ],
       "analogPins": [


### PR DESCRIPTION
The ESP32 Feather v2 has a built-in button located at GPI38, add it to WipperSnapper's definition so it's usable by components.