### PR TITLE
Add definition for BOOT button

### DIFF
--- a/boards/feather-esp32s2-tft/definition.json
+++ b/boards/feather-esp32s2-tft/definition.json
@@ -10,6 +10,11 @@
     "components":{
        "digitalPins":[
           {
+             "name":"D0",
+             "displayName":"BOOT",
+             "dataType":"bool"
+          },
+          {
              "name":"D1",
              "displayName":"D1",
              "dataType":"bool"


### PR DESCRIPTION
Added the BOOT button definition. Please review to be sure I did it correctly. The instructions are out of date and I am not sure how to test with the new py-based system. Nor the old one either for that matter.