### PR TITLE
Add changes to 8MB ESP32 boards supported by web uploader

### DIFF
--- a/boards/feather-esp32/definition.json
+++ b/boards/feather-esp32/definition.json
@@ -10,7 +10,7 @@
     "esptool": {
       "fileSystemSize": 1638400,
       "blockSize": 4096,
-      "offset": "0x670000",
+      "offset": "0x290000",
       "chip": "esp32",
       "flashMode" : "dio",
       "flashFreq" : "80m",

--- a/boards/feather-esp32/definition.json
+++ b/boards/feather-esp32/definition.json
@@ -8,9 +8,9 @@
     "documentationURL":"https://learn.adafruit.com/adafruit-huzzah32-esp32-feather",
     "installMethod":"web",
     "esptool": {
-      "fileSystemSize": 94208,
+      "fileSystemSize": 1638400,
       "blockSize": 4096,
-      "offset": "0x290000",
+      "offset": "0x670000",
       "chip": "esp32",
       "flashMode" : "dio",
       "flashFreq" : "80m",

--- a/boards/qtpy-esp32/definition.json
+++ b/boards/qtpy-esp32/definition.json
@@ -8,9 +8,9 @@
     "documentationURL":"https://learn.adafruit.com/",
     "installMethod":"web",
     "esptool": {
-        "fileSystemSize": 94208,
+        "fileSystemSize": 1638400,
         "blockSize": 4096,
-        "offset": "0x290000",
+        "offset": "0x670000",
         "chip": "esp32",
         "flashMode" : "dio",
         "flashFreq" : "80m",

--- a/boards/qtpy-esp32c3/definition.json
+++ b/boards/qtpy-esp32c3/definition.json
@@ -8,9 +8,9 @@
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-c3-wifi-dev-board",
     "installMethod":"web",
     "esptool": {
-      "fileSystemSize": 94208,
+      "fileSystemSize": 1638400,
       "blockSize": 4096,
-      "offset": "0x00290000",
+      "offset": "0x670000",
       "chip": "esp32c3",
       "flashMode" : "dio",
       "flashFreq" : "80m",


### PR DESCRIPTION
Changes made in https://github.com/espressif/arduino-esp32/commit/e10b5282cff45535f1ec6343f07526e6a3effed7 caused the default partition scheme for ESP32 boards to change with WipperSnapper beta 50 (based on arduino-esp32 v2.0.5) from `min_spiffs` to [default_8mb](default_8MB)


Previously it was using min_spiffs, which had a size of 0x30000 (or 196608), but I’m not sure why we didn’t have an error with 94208 yet. There must have been something added that started enforcing the size.



https://github.com/adafruit/Wippersnapper_Boards/pull/77/files
https://github.com/adafruit/Wippersnapper_Boards/pull/76