### PR TITLE
Update all board definitions to include neopixel or dotstar pins

### DIFF
--- a/boards/feather-esp32-v2/definition.json
+++ b/boards/feather-esp32-v2/definition.json
@@ -21,12 +21,16 @@
     },
     "components": {
       "digitalPins": [
-       {
+        {
+          "name":"D0",
+          "displayName":"D0 (NeoPixel)",
+          "dataType":"bool"
+        },
+        {
           "name":"D13",
           "displayName":"D13 (LED BUILT-IN)",
           "dataType":"bool",
-          "hasPWM":true,
-          "hasServo":true
+          "hasPWM":true
        },
        {
         "name":"D12",

--- a/boards/feather-esp32/definition.json
+++ b/boards/feather-esp32/definition.json
@@ -23,10 +23,9 @@
       "digitalPins": [
        {
          "name":"D13",
-         "displayName":"D13",
+         "displayName":"D13 (LED BUILT-IN)",
          "dataType":"bool",
-         "hasPWM":true,
-         "hasServo":true
+         "hasPWM":true
        },
        {
          "name":"D12",

--- a/boards/feather-esp32s2-tft/definition.json
+++ b/boards/feather-esp32s2-tft/definition.json
@@ -87,7 +87,13 @@
           {
              "name":"D13",
              "displayName":"D13 (LED)",
-             "dataType":"bool"
+             "dataType":"bool",
+             "hasPWM":true
+          },
+          {
+            "name":"D33",
+            "displayName":"D33 (NeoPixel)",
+            "dataType":"bool"
           }
        ],
        "analogPins":[

--- a/boards/feather-esp32s2/definition.json
+++ b/boards/feather-esp32s2/definition.json
@@ -82,8 +82,14 @@
           {
              "name":"D13",
              "displayName":"D13 (LED)",
+             "dataType":"bool",
+             "hasPWM":true
+          },
+          {
+             "name":"D33",
+             "displayName":"D33 (NeoPixel)",
              "dataType":"bool"
-          }
+         }
        ],
        "analogPins":[
           {

--- a/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
+++ b/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
@@ -102,8 +102,7 @@
             "name":"D13",
             "displayName":"D13 (LED)",
             "dataType":"bool",
-            "hasPWM":true,
-            "hasServo":true
+            "hasPWM":true
           },
           {
             "name":"D14",
@@ -111,6 +110,11 @@
             "dataType":"bool",
             "hasPWM":true,
             "hasServo":true
+          },
+          {
+            "name":"D33",
+            "displayName":"D33 (NeoPixel)",
+            "dataType":"bool"
           }
         ],
         "analogPins":[

--- a/boards/feather-esp32s3-tft/definition.json
+++ b/boards/feather-esp32s3-tft/definition.json
@@ -97,8 +97,7 @@
             "name":"D13",
             "displayName":"D13 (LED)",
             "dataType":"bool",
-            "hasPWM":true,
-            "hasServo":true
+            "hasPWM":true
           },
           {
             "name":"D14",
@@ -106,6 +105,11 @@
             "dataType":"bool",
             "hasPWM":true,
             "hasServo":true
+          },
+          {
+            "name":"D33",
+            "displayName":"D33 (NeoPixel)",
+            "dataType":"bool"
           }
         ],
         "analogPins":[

--- a/boards/feather-esp32s3/definition.json
+++ b/boards/feather-esp32s3/definition.json
@@ -106,6 +106,11 @@
           "dataType":"bool",
           "hasPWM":true,
           "hasServo":true
+        },
+        {
+          "name":"D33",
+          "displayName":"D33 (NeoPixel)",
+          "dataType":"bool"
         }
       ],
       "analogPins":[

--- a/boards/feather-esp8266/definition.json
+++ b/boards/feather-esp8266/definition.json
@@ -36,9 +36,7 @@
             "name": "D2",
             "displayName": "D2 (Blue LED)",
             "dataType": "bool",
-            "hasPWM": true,
-            "hasServo": true
-
+            "hasPWM": true
         },
         {
             "name": "D4",

--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -87,8 +87,13 @@
           },
           {
              "name":"D14",
-             "displayName":"D14",
+             "displayName":"D14 (DotStar Data)",
              "dataType":"bool"
+          },
+          {
+            "name":"D15",
+            "displayName":"D15 (DotStar Clock)",
+            "dataType":"bool"
           },
           {
              "name":"D37",

--- a/boards/magtag/definition.json
+++ b/boards/magtag/definition.json
@@ -9,7 +9,12 @@
     "installMethod":"uf2",
     "components":{
        "digitalPins":[
-          {
+        {
+             "name":"D1",
+             "displayName":"D1 (NeoPixel)",
+             "dataType":"bool"
+        },
+        {
              "name":"D15",
              "displayName":"Button A",
              "dataType":"bool"

--- a/boards/metro-m4-airliftlite-tinyusb/definition.json
+++ b/boards/metro-m4-airliftlite-tinyusb/definition.json
@@ -107,6 +107,11 @@
             "dataType": "bool",
             "hasPWM":true,
             "hasServo":true
+        },
+        {
+            "name": "D40",
+            "displayName": "D40 (NeoPixel)",
+            "dataType": "bool"
         }
       ],
       "analogPins": [

--- a/boards/metroesp32s2/definition.json
+++ b/boards/metroesp32s2/definition.json
@@ -132,8 +132,12 @@
             "name":"D42",
             "displayName":"Built-in LED",
             "dataType":"bool",
-            "hasPWM":true,
-            "hasServo":true
+            "hasPWM":true
+         },
+         {
+            "name":"D45",
+            "displayName":"D45 (NeoPixel",
+            "dataType":"bool"
          }
        ],
        "analogPins":[

--- a/boards/pyportal-tinyusb/definition.json
+++ b/boards/pyportal-tinyusb/definition.json
@@ -37,7 +37,12 @@
             "name": "D50",
             "displayName": "Speaker Enable",
             "dataType": "bool"
-          }
+        },
+        {
+            "name": "D2",
+            "displayName": "D2 (NeoPixel)",
+            "dataType": "bool"
+        }
       ],
       "analogPins": [
         {

--- a/boards/qtpy-esp32/definition.json
+++ b/boards/qtpy-esp32/definition.json
@@ -101,6 +101,11 @@
                 "name":"D0",
                 "displayName":"Boot Pushbutton",
                 "dataType":"bool"
+            },
+            {
+                "name":"D5",
+                "displayName":"D5 (NeoPixel)",
+                "dataType":"bool"
             }
         ],
         "analogPins":[

--- a/boards/qtpy-esp32c3/definition.json
+++ b/boards/qtpy-esp32c3/definition.json
@@ -102,6 +102,11 @@
                 "dataType":"bool",
                 "hasPWM":true,
                 "hasServo":true
+            },
+            {
+                "name":"D2",
+                "displayName":"D2 (NeoPixel)",
+                "dataType":"bool"
             }
         ],
         "analogPins":[

--- a/boards/qtpy-esp32s2/definition.json
+++ b/boards/qtpy-esp32s2/definition.json
@@ -77,6 +77,11 @@
                 "displayName":"Boot Pushbutton",
                 "dataType":"bool",
                 "direction":"INPUT"
+            },
+            {
+                "name":"D39",
+                "displayName":"D39 (NeoPixel)",
+                "dataType":"bool"
             }
         ],
         "analogPins":[

--- a/boards/qtpy-esp32s3/definition.json
+++ b/boards/qtpy-esp32s3/definition.json
@@ -91,6 +91,11 @@
                 "displayName":"Boot Pushbutton",
                 "dataType":"bool",
                 "direction":"INPUT"
+            },
+            {
+                "name":"D39",
+                "displayName":"D39 (NeoPixel)",
+                "dataType":"bool"
             }
         ],
         "analogPins":[


### PR DESCRIPTION
* Updates the definitions for boards with on-board NeoPixels or DotStar components to include GPIO access to the component from WipperSnapper
* Removes erroneous `hasServo` field from some built-in LED pin components