### PR TITLE
Match Feather Huzzah32 analog pins to `pins_arduino`

### DIFF
--- a/boards/feather-esp32/definition.json
+++ b/boards/feather-esp32/definition.json
@@ -108,92 +108,92 @@
       ],
       "analogPins": [
        {
-          "name":"A0",
+          "name":"26",
           "displayName":"A0",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A1",
+          "name":"25",
           "displayName":"A1",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A2",
+          "name":"34",
           "displayName":"A2",
           "dataType":"int16"
        },
        {
-          "name":"A3",
+          "name":"39",
           "displayName":"A3",
           "dataType":"int16"
        },
        {
-          "name":"A4",
+          "name":"36",
           "displayName":"A4",
           "dataType":"int16"
        },
        {
-          "name":"A5",
+          "name":"4",
           "displayName":"A5",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A6",
+          "name":"14",
           "displayName":"A6",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A7",
+          "name":"32",
           "displayName":"A7",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A8",
+          "name":"15",
           "displayName":"A8",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A9",
+          "name":"33",
           "displayName":"A9",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A10",
+          "name":"27",
           "displayName":"A10",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A11",
+          "name":"12",
           "displayName":"A11",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A12",
+          "name":"13",
           "displayName":"A12",
           "dataType":"int16",
           "hasPWM":true,
           "hasServo":true
        },
        {
-          "name":"A13",
+          "name":"35",
           "displayName":"VBAT",
           "dataType":"int16"
        }


### PR DESCRIPTION
Applying mapping from `…variants/feather_esp32/pins_arduino.h`:

```
// mapping to match other feathers and also in order
static const uint8_t A0 = 26; 
static const uint8_t A1 = 25;
static const uint8_t A2 = 34;
static const uint8_t A3 = 39;
static const uint8_t A4 = 36;
static const uint8_t A5 = 4;
static const uint8_t A6 = 14;
static const uint8_t A7 = 32;
static const uint8_t A8 = 15;
static const uint8_t A9 = 33;
static const uint8_t A10 = 27;
static const uint8_t A11 = 12;
static const uint8_t A12 = 13;

// vbat measure
static const uint8_t BATT_MONITOR = 35;
static const uint8_t A13 = 35;
```

May fix: https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/406