### PR TITLE
Add note for QT PY ESP32-S2 A0 Pin

### DIFF
--- a/boards/qtpy-esp32/definition.json
+++ b/boards/qtpy-esp32/definition.json
@@ -111,7 +111,7 @@
         "analogPins":[
             {
                 "name":"A26",
-                "displayName":"A0",
+                "displayName":"A0 (OUTPUT ONLY!)",
                 "dataType":"int16",
                 "hasPWM":true
             },


### PR DESCRIPTION
The A0 pin on the QT PY ESP32-S2 is pulled up to 3.3V. Making a note on the `displayName` to signal that this pin should be used as an output-only pin.

From the Learn Guide,

"Note that A0 has a 10K pullup to 3.3V - we're not sure why but this is [required by the hardware design notes for the ESP32-S2 (see Fig 1).](https://www.espressif.com/sites/default/files/documentation/esp32-s2_hardware_design_guidelines_en.pdf)"


Resolves https://github.com/adafruit/Wippersnapper_Boards/issues/101