### PR TITLE
Adding some UART board definitions to match specification

### DIFF
--- a/boards/feather-esp32-v2/definition.json
+++ b/boards/feather-esp32-v2/definition.json
@@ -27,6 +27,18 @@
           "dataType":"bool"
         },
         {
+            "name":"D7",
+            "displayName":"D7 (UART RX)",
+            "dataType":"bool",
+            "uartRx": true
+        },
+        {
+            "name":"D8",
+            "displayName":"D8 (UART TX)",
+            "dataType":"bool",
+            "uartTx": true
+        },
+        {
           "name":"D13",
           "displayName":"D13 (LED BUILT-IN)",
           "dataType":"bool",

--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -115,14 +115,12 @@
           {
             "name":"D10",
             "displayName":"D10",
-            "dataType":"bool",
-            "uartTx": true
+            "dataType":"bool"
          },
          {
             "name":"D11",
             "displayName":"D11",
-            "dataType":"bool",
-            "uartRx": true
+            "dataType":"bool"
          },
          {
             "name":"D43",

--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -111,7 +111,31 @@
              "displayName":"Speaker/Piezo",
              "dataType":"bool",
              "hasPWM":true
-          }
+          },
+          {
+            "name":"D10",
+            "displayName":"D10",
+            "dataType":"bool",
+            "uartTx": true
+         },
+         {
+            "name":"D11",
+            "displayName":"D11",
+            "dataType":"bool",
+            "uartRx": true
+         },
+         {
+            "name":"D43",
+            "displayName":"D44 (UART RX)",
+            "dataType":"bool",
+            "uartTx": true
+         },
+         {
+            "name":"D43",
+            "displayName":"D43 (UART TX)",
+            "dataType":"bool",
+            "uartTx": true
+         }
        ],
        "analogPins":[
           {

--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -126,7 +126,7 @@
             "name":"D43",
             "displayName":"D44 (UART RX)",
             "dataType":"bool",
-            "uartTx": true
+            "uartRx": true
          },
          {
             "name":"D43",

--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -123,7 +123,7 @@
             "dataType":"bool"
          },
          {
-            "name":"D43",
+            "name":"D44",
             "displayName":"D44 (UART RX)",
             "dataType":"bool",
             "uartRx": true

--- a/boards/qtpy-esp32/definition.json
+++ b/boards/qtpy-esp32/definition.json
@@ -56,6 +56,14 @@
                 "hasServo":true
             },
             {
+                "name":"D32",
+                "displayName":"D32 (UART TX)",
+                "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true,
+                "uartTx":true
+            },
+            {
                 "name":"D33",
                 "displayName":"SCL",
                 "dataType":"bool",
@@ -92,10 +100,11 @@
             },
             {
                 "name":"D7",
-                "displayName":"RX",
+                "displayName":"D7 (UART RX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartRx":true
             },
             {
                 "name":"D0",

--- a/boards/qtpy-esp32c3/definition.json
+++ b/boards/qtpy-esp32c3/definition.json
@@ -91,17 +91,19 @@
             },
             {
                 "name":"D20",
-                "displayName":"D20 (RX)",
+                "displayName":"D20 (UART TX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartTx":true
             },
             {
                 "name":"D21",
-                "displayName":"D21 (TX)",
+                "displayName":"D21 (UART RX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartRx":true
             },
             {
                 "name":"D2",

--- a/boards/qtpy-esp32s2/definition.json
+++ b/boards/qtpy-esp32s2/definition.json
@@ -49,8 +49,9 @@
             },
             {
                 "name":"D5",
-                "displayName":"TX",
-                "dataType":"bool"
+                "displayName":"D5 (UART TX)",
+                "dataType":"bool",
+                "uartTx": true
             },
             {
                 "name":"D35",
@@ -69,8 +70,9 @@
             },
             {
                 "name":"D16",
-                "displayName":"RX",
-                "dataType":"bool"
+                "displayName":"D16 (UART RX)",
+                "dataType":"bool",
+                "uartRx": true
             },
             {
                 "name":"D0",

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -53,10 +53,11 @@
             },
             {
                 "name":"D5",
-                "displayName":"TX",
+                "displayName":"D5 (UART TX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartTx":true
             },
             {
                 "name":"D35",
@@ -81,10 +82,11 @@
             },
             {
                 "name":"D16",
-                "displayName":"RX",
+                "displayName":"D16 (UART RX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartRx":true
             },
             {
                 "name":"D0",

--- a/boards/qtpy-esp32s3/definition.json
+++ b/boards/qtpy-esp32s3/definition.json
@@ -53,10 +53,11 @@
             },
             {
                 "name":"D5",
-                "displayName":"TX",
+                "displayName":"D5 (UART TX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartTx":true
             },
             {
                 "name":"D35",
@@ -81,10 +82,11 @@
             },
             {
                 "name":"D16",
-                "displayName":"RX",
+                "displayName":"D16 (UART RX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartRx":true
             },
             {
                 "name":"D0",


### PR DESCRIPTION
This pull request adds some uart board definition json files to match the specification decided on in https://github.com/adafruit/Wippersnapper_Boards/pull/115 and check the validator