### PR TITLE
Fixup pin definitions for UART + Analog

### DIFF
--- a/boards/feather-esp32/definition.json
+++ b/boards/feather-esp32/definition.json
@@ -104,6 +104,18 @@
          "dataType":"bool",
          "hasPWM":true,
          "hasServo":true
+       },
+       {
+         "name": "D16",
+         "displayName": "D16 (UART RX)",
+         "dataType": "bool",
+         "uartRx": true
+       },
+       {
+         "name": "D17",
+         "displayName": "D17 (UART TX)",
+         "dataType": "bool",
+         "uartTx": true
        }
       ],
       "analogPins": [
@@ -124,16 +136,19 @@
        {
           "name":"A34",
           "displayName":"A2",
+          "direction": "INPUT",
           "dataType":"int16"
        },
        {
           "name":"A39",
           "displayName":"A3",
+          "direction": "INPUT",
           "dataType":"int16"
        },
        {
           "name":"A36",
           "displayName":"A4",
+          "direction": "INPUT",
           "dataType":"int16"
        },
        {

--- a/boards/feather-esp32s2-reverse-tft/definition.json
+++ b/boards/feather-esp32s2-reverse-tft/definition.json
@@ -81,6 +81,18 @@
             "name":"D21",
             "displayName":"D21 (NeoPixel Power Pin)",
             "dataType":"bool"
+          },
+          {
+            "name": "D38",
+            "displayName": "D38 (UART RX)",
+            "dataType": "bool",
+            "uartRx": true
+          },
+          {
+            "name": "D39",
+            "displayName": "D39 (UART TX)",
+            "dataType": "bool",
+            "uartTx": true
           }
         ],
         "analogPins":[

--- a/boards/feather-esp32s2-tft/definition.json
+++ b/boards/feather-esp32s2-tft/definition.json
@@ -1,143 +1,157 @@
 {
-    "boardName":"feather-esp32s2-tft",
-    "mcuName":"esp32s2",
-    "mcuRefVoltage":2.6,
-    "displayName":"Adafruit ESP32-S2 TFT Feather",
-    "vendor":"Adafruit",
-    "productPageURL":"https://www.adafruit.com/product/5300",
-    "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s2-tft-feather",
-    "installMethod":"uf2",
-    "components":{
-       "digitalPins":[
-        {
-            "name":"D0",
-            "displayName":"D0 (Boot Btn)",
-            "dataType":"bool"
-        },
-        {
-             "name":"D1",
-             "displayName":"D1",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D2",
-             "displayName":"D2",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D3",
-             "displayName":"D3",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D4",
-             "displayName":"D4",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D5",
-             "displayName":"D5",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D6",
-             "displayName":"D6",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D9",
-             "displayName":"D9",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D10",
-             "displayName":"D10",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D11",
-             "displayName":"D11",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D12",
-             "displayName":"D12",
-             "dataType":"bool",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"D13",
-             "displayName":"D13 (LED)",
-             "dataType":"bool",
-             "hasPWM":true
-          },
-          {
-            "name":"D33",
-            "displayName":"D33 (NeoPixel)",
-            "dataType":"bool"
-          }
-       ],
-       "analogPins":[
-          {
-             "name":"A18",
-             "displayName":"A0",
-             "dataType":"int16",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"A17",
-             "displayName":"A1",
-             "dataType":"int16",
-             "hasPWM":true,
-             "hasServo":true
-          },
-          {
-             "name":"A16",
-             "displayName":"A2",
-             "dataType":"int16"
-          },
-          {
-             "name":"A15",
-             "displayName":"A3",
-             "dataType":"int16"
-          },
-          {
-             "name":"A14",
-             "displayName":"A4",
-             "dataType":"int16"
-          },
-          {
-             "name":"A8",
-             "displayName":"A5",
-             "dataType":"int16"
-          }
-       ],
-       "i2cPorts":[
-          {
-             "i2cPortId":0,
-             "SDA":42,
-             "SCL":41
-          }
-       ]
-    }
- }
+   "boardName": "feather-esp32s2-tft",
+   "mcuName": "esp32s2",
+   "mcuRefVoltage": 2.6,
+   "displayName": "Adafruit ESP32-S2 TFT Feather",
+   "vendor": "Adafruit",
+   "productPageURL": "https://www.adafruit.com/product/5300",
+   "documentationURL": "https://learn.adafruit.com/adafruit-esp32-s2-tft-feather",
+   "installMethod": "uf2",
+   "components": {
+      "digitalPins": [
+         {
+            "name": "D0",
+            "displayName": "D0 (Boot Btn)",
+            "dataType": "bool"
+         },
+         {
+            "name": "D1",
+            "displayName": "D1 (UART TX)",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true,
+            "uartTx": true
+         },
+         {
+            "name": "D2",
+            "displayName": "D2 (UART RX)",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true,
+            "uartRx": true
+         },
+         {
+            "name": "D3",
+            "displayName": "D3",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D4",
+            "displayName": "D4",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D5",
+            "displayName": "D5",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D6",
+            "displayName": "D6",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D9",
+            "displayName": "D9",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D10",
+            "displayName": "D10",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D11",
+            "displayName": "D11",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D12",
+            "displayName": "D12",
+            "dataType": "bool",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "D13",
+            "displayName": "D13 (LED)",
+            "dataType": "bool",
+            "hasPWM": true
+         },
+         {
+            "name": "D33",
+            "displayName": "D33 (NeoPixel)",
+            "dataType": "bool"
+         },
+         {
+            "name": "D38",
+            "displayName": "D38 (UART RX)",
+            "dataType": "bool",
+            "uartRx": true
+         },
+         {
+            "name": "D39",
+            "displayName": "D39 (UART TX)",
+            "dataType": "bool",
+            "uartTx": true
+         }
+      ],
+      "analogPins": [
+         {
+            "name": "A18",
+            "displayName": "A0",
+            "dataType": "int16",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "A17",
+            "displayName": "A1",
+            "dataType": "int16",
+            "hasPWM": true,
+            "hasServo": true
+         },
+         {
+            "name": "A16",
+            "displayName": "A2",
+            "dataType": "int16"
+         },
+         {
+            "name": "A15",
+            "displayName": "A3",
+            "dataType": "int16"
+         },
+         {
+            "name": "A14",
+            "displayName": "A4",
+            "dataType": "int16"
+         },
+         {
+            "name": "A8",
+            "displayName": "A5",
+            "dataType": "int16"
+         }
+      ],
+      "i2cPorts": [
+         {
+            "i2cPortId": 0,
+            "SDA": 42,
+            "SCL": 41
+         }
+      ]
+   }
+}

--- a/boards/feather-esp32s2/definition.json
+++ b/boards/feather-esp32s2/definition.json
@@ -94,6 +94,18 @@
             "name":"D0",
             "displayName":"BOOT Push Button",
             "dataType":"bool"
+         },
+         {
+           "name": "D38",
+           "displayName": "D38 (UART RX)",
+           "dataType": "bool",
+           "uartRx": true
+         },
+         {
+           "name": "D39",
+           "displayName": "D39 (UART TX)",
+           "dataType": "bool",
+           "uartTx": true
          }
        ],
        "analogPins":[

--- a/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
+++ b/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
@@ -115,6 +115,18 @@
             "name":"D33",
             "displayName":"D33 (NeoPixel)",
             "dataType":"bool"
+          },
+          {
+            "name": "D38",
+            "displayName": "D38 (UART RX)",
+            "dataType": "bool",
+            "uartRx": true
+          },
+          {
+            "name": "D39",
+            "displayName": "D39 (UART TX)",
+            "dataType": "bool",
+            "uartTx": true
           }
         ],
         "analogPins":[

--- a/boards/feather-esp32s3-reverse-tft/definition.json
+++ b/boards/feather-esp32s3-reverse-tft/definition.json
@@ -5,7 +5,7 @@
     "displayName":"ESP32-S3 Reverse TFT Feather",
     "vendor":"Adafruit",
     "productPageURL":"https://www.adafruit.com/product/5691",
-    "documentationURL":"https://www.adafruit.com/product/5691",
+    "documentationURL": "https://learn.adafruit.com/esp32-s3-reverse-tft-feather",
     "installMethod":"uf2",
     "components":{
         "digitalPins":[
@@ -76,6 +76,18 @@
             "name":"D33",
             "displayName":"D33 (NeoPixel)",
             "dataType":"bool"
+          },
+          {
+            "name": "D38",
+            "displayName": "D38 (UART RX)",
+            "dataType": "bool",
+            "uartRx": true
+          },
+          {
+            "name": "D39",
+            "displayName": "D39 (UART TX)",
+            "dataType": "bool",
+            "uartTx": true
           }
         ],
         "analogPins":[

--- a/boards/feather-esp32s3-tft/definition.json
+++ b/boards/feather-esp32s3-tft/definition.json
@@ -11,17 +11,19 @@
         "digitalPins":[
           {
             "name":"D1",
-            "displayName":"D1",
+            "displayName": "D1 (UART TX)",
             "dataType":"bool",
             "hasPWM":true,
-            "hasServo":true
+            "hasServo": true,
+            "uartTx": true
           },
           {
             "name":"D2",
-            "displayName":"D2",
+            "displayName": "D2 (UART RX)",
             "dataType":"bool",
             "hasPWM":true,
-            "hasServo":true
+            "hasServo": true,
+            "uartRx": true
           },
           {
             "name":"D3",

--- a/boards/feather-esp8266/definition.json
+++ b/boards/feather-esp8266/definition.json
@@ -54,10 +54,11 @@
         },
         {
             "name": "D12",
-            "displayName": "D12",
+            "displayName": "D12 (UART TX)",
             "dataType": "bool",
             "hasPWM": true,
-            "hasServo": true
+            "hasServo": true,
+            "uartTx": true
         },
         {
             "name": "D13",
@@ -68,10 +69,11 @@
         },
         {
             "name": "D14",
-            "displayName": "D14",
+            "displayName": "D14 (UART RX)",
             "dataType": "bool",
             "hasPWM": true,
-            "hasServo": true
+            "hasServo": true,
+            "uartRx": true
         },
         {
             "name": "D15",

--- a/boards/feather-esp8266/definition.json
+++ b/boards/feather-esp8266/definition.json
@@ -54,11 +54,11 @@
         },
         {
             "name": "D12",
-            "displayName": "D12 (UART TX)",
+            "displayName": "D12 (UART RX)",
             "dataType": "bool",
             "hasPWM": true,
             "hasServo": true,
-            "uartTx": true
+            "uartRx": true
         },
         {
             "name": "D13",
@@ -69,11 +69,11 @@
         },
         {
             "name": "D14",
-            "displayName": "D14 (UART RX)",
+            "displayName": "D14 (UART TX)",
             "dataType": "bool",
             "hasPWM": true,
             "hasServo": true,
-            "uartRx": true
+            "uartTx": true
         },
         {
             "name": "D15",

--- a/boards/magtag/definition.json
+++ b/boards/magtag/definition.json
@@ -53,7 +53,21 @@
              "displayName":"Built-in LED",
              "dataType":"bool",
              "hasPWM":true
-          }
+          },
+          {
+             "name":"D43",
+             "displayName":"D43 (UART TX)",
+             "dataType":"bool",
+             "hasPWM":false,
+             "uartTx":true
+          },
+          {
+            "name":"D44",
+            "displayName":"D44 (UART RX)",
+            "dataType":"bool",
+            "hasPWM":false,
+            "uartRx":true
+         }
        ],
        "analogPins":[
            {

--- a/boards/metro-m4-airliftlite-tinyusb/definition.json
+++ b/boards/metro-m4-airliftlite-tinyusb/definition.json
@@ -12,17 +12,19 @@
       "digitalPins": [
         {
             "name": "D0",
-            "displayName": "D0",
+            "displayName": "D0 (UART RX)",
             "dataType": "bool",
             "hasPWM":true,
-            "hasServo":true
+            "hasServo":true,
+            "uartRx":true
         },
         {
             "name": "D1",
-            "displayName": "D1",
+            "displayName": "D1 (UART TX)",
             "dataType": "bool",
             "hasPWM":true,
-            "hasServo":true
+            "hasServo":true,
+            "uartTx":true
         },
         {
             "name": "D2",

--- a/boards/metroesp32s2/definition.json
+++ b/boards/metroesp32s2/definition.json
@@ -39,17 +39,19 @@
          },
          {
             "name":"D5",
-            "displayName":"D5",
+            "displayName":"D5 (UART TX)",
             "dataType":"bool",
             "hasPWM":true,
-            "hasServo":true
+            "hasServo":true,
+            "uartTx":true
          },
          {
             "name":"D6",
-            "displayName":"D6",
+            "displayName":"D6 (UART RX)",
             "dataType":"bool",
             "hasPWM":true,
-            "hasServo":true
+            "hasServo":true,
+            "uartRx":true
          },
          {
             "name":"D7",

--- a/boards/mkrwifi1010/definition.json
+++ b/boards/mkrwifi1010/definition.json
@@ -76,13 +76,15 @@
           },
           {
              "name":"D13",
-             "displayName":"D13",
-             "dataType":"bool"
+             "displayName":"D13 (UART RX)",
+             "dataType":"bool",
+             "uartRx":true
           },
           {
              "name":"D14",
-             "displayName":"D14",
-             "dataType":"bool"
+             "displayName":"D14 (UART TX)",
+             "dataType":"bool",
+             "uartTx":true
           }
        ],
        "analogPins":[

--- a/boards/nano-33-iot/definition.json
+++ b/boards/nano-33-iot/definition.json
@@ -10,6 +10,18 @@
     "components":{
        "digitalPins":[
           {
+             "name":"TX",
+             "displayName":"TX",
+             "dataType":"bool",
+             "uartTx":true
+          },
+          {
+             "name":"RX",
+             "displayName":"RX",
+             "dataType":"bool",
+             "uartRx":true
+          },
+          {
              "name":"D2",
              "displayName":"D2",
              "dataType":"bool"

--- a/boards/qtpy-esp32/definition.json
+++ b/boards/qtpy-esp32/definition.json
@@ -5,7 +5,7 @@
     "displayName":"Adafruit QT Py ESP32 Pico",
     "vendor":"Adafruit",
     "productPageURL":"https://www.adafruit.com/product/5395",
-    "documentationURL":"https://learn.adafruit.com/",
+    "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-pico",
     "installMethod":"web",
     "esptool": {
         "fileSystemSize": 1572864,
@@ -56,14 +56,6 @@
                 "hasServo":true
             },
             {
-                "name":"D32",
-                "displayName":"D32 (UART TX)",
-                "dataType":"bool",
-                "hasPWM":true,
-                "hasServo":true,
-                "uartTx":true
-            },
-            {
                 "name":"D33",
                 "displayName":"SCL",
                 "dataType":"bool",
@@ -72,10 +64,11 @@
             },
             {
                 "name":"D32",
-                "displayName":"TX",
+                "displayName":"D32 (UART TX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartTx":true
             },
             {
                 "name":"D13",
@@ -155,6 +148,20 @@
             {
                 "name":"A33",
                 "displayName":"SCL",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A32",
+                "displayName":"A32 (UART TX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A7",
+                "displayName":"A7 (UART RX)",
                 "dataType":"int16",
                 "hasPWM":true,
                 "hasServo":true

--- a/boards/qtpy-esp32c3/definition.json
+++ b/boards/qtpy-esp32c3/definition.json
@@ -146,6 +146,20 @@
                 "dataType":"int16",
                 "hasPWM":true,
                 "hasServo":true
+            },
+            {
+                "name":"A20",
+                "displayName":"A20 (UART TX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A21",
+                "displayName":"A21 (UART RX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             }
         ],
         "i2cPorts":[

--- a/boards/qtpy-esp32s2/definition.json
+++ b/boards/qtpy-esp32s2/definition.json
@@ -40,38 +40,52 @@
             {
                 "name":"D7",
                 "displayName":"SDA",
-                "dataType":"bool"
+                "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"D6",
                 "displayName":"SCL",
-                "dataType":"bool"
+                "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"D5",
                 "displayName":"D5 (UART TX)",
                 "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true,
                 "uartTx": true
             },
             {
                 "name":"D35",
                 "displayName":"MOSI",
-                "dataType":"bool"
+                "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"D37",
                 "displayName":"MISO",
-                "dataType":"bool"
+                "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"D36",
                 "displayName":"SCK",
-                "dataType":"bool"
+                "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"D16",
                 "displayName":"D16 (UART RX)",
                 "dataType":"bool",
+                "hasPWM":true,
+                "hasServo":true,
                 "uartRx": true
             },
             {
@@ -104,26 +118,44 @@
             {
                 "name":"A9",
                 "displayName":"A2",
-                "direction":"INPUT",
-                "dataType":"int16"
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"A8",
                 "displayName":"A3",
-                "direction":"INPUT",
-                "dataType":"int16"
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"A7",
                 "displayName":"SDA",
-                "direction":"INPUT",
-                "dataType":"int16"
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             },
             {
                 "name":"A6",
                 "displayName":"SCL",
-                "direction":"INPUT",
-                "dataType":"int16"
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A5",
+                "displayName":"A5 (UART TX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A16",
+                "displayName":"A16 (UART RX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             }
         ],
         "i2cPorts":[

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -142,6 +142,20 @@
                 "dataType":"int16",
                 "hasPWM":true,
                 "hasServo":true
+            },
+            {
+                "name":"A5",
+                "displayName":"A5 (UART TX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A16",
+                "displayName":"A16 (UART RX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             }
         ],
         "i2cPorts":[

--- a/boards/qtpy-esp32s3/definition.json
+++ b/boards/qtpy-esp32s3/definition.json
@@ -142,6 +142,20 @@
                 "dataType":"int16",
                 "hasPWM":true,
                 "hasServo":true
+            },
+            {
+                "name":"A5",
+                "displayName":"A5 (UART TX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
+            },
+            {
+                "name":"A16",
+                "displayName":"A16 (UART RX)",
+                "dataType":"int16",
+                "hasPWM":true,
+                "hasServo":true
             }
         ],
         "i2cPorts":[

--- a/boards/rpi-pico-w/definition.json
+++ b/boards/rpi-pico-w/definition.json
@@ -11,17 +11,19 @@
         "digitalPins":[
             {
                 "name":"D0",
-                "displayName":"GP0",
+                "displayName":"GP0 (UART TX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartTx":true
             },
             {
                 "name":"D1",
-                "displayName":"GP1",
+                "displayName":"GP1 (UART RX)",
                 "dataType":"bool",
                 "hasPWM":true,
-                "hasServo":true
+                "hasServo":true,
+                "uartRx":true
             },
             {
                 "name":"D2",


### PR DESCRIPTION
Removes duplicate pin and fixes order in QT Py ESP32 Pico.
Specify all PWM pins as servo+pwm compatible.
Restrict Feather ESP32 v1 A2-A4 input only