### PR TITLE
Remove duplicate Funhouse pins

### DIFF
--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -112,16 +112,6 @@
              "dataType":"bool",
              "hasPWM":true
           },
-          {
-            "name":"D10",
-            "displayName":"D10",
-            "dataType":"bool"
-         },
-         {
-            "name":"D11",
-            "displayName":"D11",
-            "dataType":"bool"
-         },
          {
             "name":"D44",
             "displayName":"D44 (UART RX)",


### PR DESCRIPTION
We somehow duplicated 2 funhouse pins when doing the first uart properties, this reverts that.