### PR TITLE
Add analog pins for digital use + SCK/MOSI/MISO

### DIFF
--- a/boards/feather-esp32-v2/definition.json
+++ b/boards/feather-esp32-v2/definition.json
@@ -88,17 +88,66 @@
        },
        {
         "name":"D26",
-        "displayName":"D26",
+        "displayName":"D26 (A0)",
         "dataType":"bool",
         "hasPWM":true,
         "hasServo":true
        },
        {
         "name":"D25",
-        "displayName":"D25",
+        "displayName":"D25 (A1)",
         "dataType":"bool",
         "hasPWM":true,
         "hasServo":true
+       },
+       {
+         "name":"D34",
+         "displayName":"D34 (A2)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
+       },
+       {
+         "name":"D39",
+         "displayName":"D39 (A3)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
+       },
+       {
+         "name":"D36",
+         "displayName":"D36 (A4)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
+       },
+       {
+         "name":"D4",
+         "displayName":"D4 (A5)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
+       },
+       {
+         "name":"D5",
+         "displayName":"D5 (SCK)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
+       },
+       {
+         "name":"D19",
+         "displayName":"D19 (MOSI)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
+       },
+       {
+         "name":"D21",
+         "displayName":"D21 (MISO)",
+         "dataType":"bool",
+         "hasPWM":true,
+         "hasServo":true
        },
        {
         "name":"D37",


### PR DESCRIPTION
While updating the IO Basics guide it was noticed that Pin5 was unaviable for selection in WipperSnapper.

@brentu