### PR TITLE
Update definition.json - fix displayname for A4/D36

### DIFF
--- a/boards/feather-esp32/definition.json
+++ b/boards/feather-esp32/definition.json
@@ -95,7 +95,7 @@
        },
        {
          "name":"D36",
-         "displayName":"D34 (A4)",
+         "displayName":"D36 (A4)",
          "dataType":"bool"
        },
        {


### PR DESCRIPTION
This will be a harmless fix, just UI label update that I spotted while using the huzzah for a project