### PR TITLE
Remove builtin LED from FunHouse definition

### DIFF
--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -96,12 +96,6 @@
             "dataType":"bool"
           },
           {
-             "name":"D37",
-             "displayName":"Built-in LED",
-             "dataType":"bool",
-             "hasPWM":true
-          },
-          {
              "name":"D16",
              "displayName":"PIR Sensor",
              "dataType":"bool"

--- a/boards/funhouse/magic.json
+++ b/boards/funhouse/magic.json
@@ -100,14 +100,6 @@
       "selected": false
     },
     {
-      "name": "LED",
-      "pinName": "D37",
-      "type": "led",
-      "mode": "DIGITAL",
-      "direction": "OUTPUT",
-      "isPin": true
-    },
-    {
       "name": "Light Sensor",
       "pinName": "A18",
       "type": "light_sensor",


### PR DESCRIPTION
Resolves https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/525 by removing the funhouse's builtin LED (which causes a collision with the MISO pin from the SPI bus).

See analysis and reasoning here:
https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/525#issuecomment-1875695951