### PR TITLE
Feather s2 migration

### DIFF
--- a/boards/esp32s3-devkitc-1-n8/definition.json
+++ b/boards/esp32s3-devkitc-1-n8/definition.json
@@ -9,6 +9,7 @@
     "installMethod":"web-native-usb",
     "installBoardName": "esp32s3-devkitc-1-n8",
     "bootDiskName": "S3DKC1BOOT",
+    "bootloaderBoardName": "espressif_esp32s3_devkitc_1",
     "esptool": {
       "fileSystemSize": 1572864,
       "blockSize": 4096,

--- a/boards/feather-esp32s2-reverse-tft/definition.json
+++ b/boards/feather-esp32s2-reverse-tft/definition.json
@@ -6,7 +6,8 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5345",
     "documentationURL":"https://learn.adafruit.com/esp32-s2-reverse-tft-feather",
-    "installMethod":"uf2",
+    "installMethod": "uf2",
+    "bootloaderBoardName": "adafruit_feather_esp32s2_reverse_tft",
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s2-tft/definition.json
+++ b/boards/feather-esp32s2-tft/definition.json
@@ -7,6 +7,7 @@
    "productURL": "https://www.adafruit.com/product/5300",
    "documentationURL": "https://learn.adafruit.com/adafruit-esp32-s2-tft-feather",
    "installMethod": "uf2",
+   "bootloaderBoardName": "adafruit_feather_esp32s2_tft",
    "components": {
       "digitalPins": [
          {

--- a/boards/feather-esp32s2/definition.json
+++ b/boards/feather-esp32s2/definition.json
@@ -6,9 +6,21 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5000",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s2-feather",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
     "bootDiskName": "FTHRS2BOOT",
     "bootloaderBoardName": "adafruit_feather_esp32s2",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.feather_esp32s2.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
        "digitalPins":[
          {

--- a/boards/feather-esp32s2/definition.json
+++ b/boards/feather-esp32s2/definition.json
@@ -7,6 +7,8 @@
     "productURL":"https://www.adafruit.com/product/5000",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s2-feather",
     "installMethod":"uf2",
+    "bootDiskName": "FTHRS2BOOT",
+    "bootloaderBoardName": "adafruit_feather_esp32s2",
     "components":{
        "digitalPins":[
          {

--- a/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
+++ b/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/5477",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-feather",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_feather_esp32s3",
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s3-reverse-tft/definition.json
+++ b/boards/feather-esp32s3-reverse-tft/definition.json
@@ -8,6 +8,7 @@
     "productURL":"https://www.adafruit.com/product/5691",
     "documentationURL": "https://learn.adafruit.com/esp32-s3-reverse-tft-feather",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_feather_esp32s3_reverse_tft",
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s3-tft/definition.json
+++ b/boards/feather-esp32s3-tft/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/5483",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-tft-feather",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_feather_esp32s3_tft",
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s3/definition.json
+++ b/boards/feather-esp32s3/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/5000",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-feather",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_feather_esp32s3_nopsram",
     "components":{
       "digitalPins":[
         {

--- a/boards/funhouse/definition.json
+++ b/boards/funhouse/definition.json
@@ -8,6 +8,7 @@
     "documentationURL":"https://learn.adafruit.com/adafruit-funhouse",
     "installMethod":"web-native-usb",
     "installBoardName": "funhouse_noota",
+    "bootloaderBoardName": "adafruit_funhouse_esp32s2",
     "esptool": {
       "fileSystemSize": 983040,
       "blockSize": 4096,

--- a/boards/magtag/definition.json
+++ b/boards/magtag/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/4800",
     "documentationURL":"https://learn.adafruit.com/adafruit-magtag",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_magtag_29gray",
     "components":{
        "digitalPins":[
         {

--- a/boards/metroesp32s2/definition.json
+++ b/boards/metroesp32s2/definition.json
@@ -7,6 +7,7 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/4775",
     "documentationURL":"https://learn.adafruit.com/adafruit-metro-esp32-s2",
+    "bootloaderBoardName": "adafruit_metro_esp32s2",
     "installMethod":"uf2",
     "components":{
        "digitalPins":[

--- a/boards/metroesp32s3/definition.json
+++ b/boards/metroesp32s3/definition.json
@@ -9,6 +9,7 @@
     "bootDiskName": "METROS3BOOT",
     "installMethod":"uf2",
     "installBoardName": "metro_esp32s3",
+    "bootloaderBoardName": "adafruit_metro_esp32s3",
     "published":true,
     "components":{
        "digitalPins":[
@@ -188,7 +189,7 @@
             "hasPWM":true,
             "hasServo":true
          },
-         
+
          {
             "name":"D39",
             "displayName":"D39 (SCK)",

--- a/boards/qtpy-esp32s2/definition.json
+++ b/boards/qtpy-esp32s2/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/5325",
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-s2",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_qtpy_esp32s2",
     "components":{
         "digitalPins":[
             {

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/5700",
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-s3",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_qtpy_esp32s3_n4r2",
     "components":{
         "digitalPins":[
             {

--- a/boards/qtpy-esp32s3/definition.json
+++ b/boards/qtpy-esp32s3/definition.json
@@ -7,6 +7,7 @@
     "productURL":"https://www.adafruit.com/product/5426",
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-s3",
     "installMethod":"uf2",
+    "bootloaderBoardName": "adafruit_qtpy_esp32s3",
     "components":{
         "digitalPins":[
             {

--- a/boards/schema.json
+++ b/boards/schema.json
@@ -17,6 +17,12 @@
       "minLength": 1,
       "maxLength": 40
     },
+    "bootloaderDeviceName": {
+      "description": "The name of the board as it appears in tinyuf2 release files. e.g. adafruit_feather_esp32s3",
+      "type": "string",
+      "minLength": 3,
+      "maxLength": 60
+    },
     "mcuName": {
       "description": "Microcontroller name.",
       "type": "string",

--- a/boards/schema.json
+++ b/boards/schema.json
@@ -17,7 +17,7 @@
       "minLength": 1,
       "maxLength": 40
     },
-    "bootloaderDeviceName": {
+    "bootloaderBoardName": {
       "description": "The name of the board as it appears in tinyuf2 release files. e.g. adafruit_feather_esp32s3",
       "type": "string",
       "minLength": 3,

--- a/boards/xiao-esp32s3/definition.json
+++ b/boards/xiao-esp32s3/definition.json
@@ -8,6 +8,7 @@
     "documentationURL":"https://wiki.seeedstudio.com/xiao_esp32s3_getting_started/",
     "published": false,
     "installMethod":"web-native-usb",
+    "bootloaderBoardName": "seeed_xiao_esp32s3",
     "bootDiskName": "XIAOS3BOOT",
     "esptool": {
       "fileSystemSize": 1572864,


### PR DESCRIPTION
This migrates just the feather S2 definition from UF2 to web-native-usb (esptool method).

It depends on a release of the feather s2 with the Sx/LvGL build task, as it generates web-native-usb zip of partition files + uf2, more like littlefs boards, instead of just app .bin and .uf2