### PR TITLE
Migrate 4MB S3 Boards to esptool

### DIFF
--- a/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
+++ b/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
@@ -6,8 +6,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5477",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-feather",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_feather_esp32s3",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s3",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.feather_esp32s3_4mbflash_2mbpsram.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s3-reverse-tft/definition.json
+++ b/boards/feather-esp32s3-reverse-tft/definition.json
@@ -7,8 +7,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5691",
     "documentationURL": "https://learn.adafruit.com/esp32-s3-reverse-tft-feather",
-    "installMethod":"uf2",
     "bootloaderBoardName": "adafruit_feather_esp32s3_reverse_tft",
+    "installMethod": "web-native-usb",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s3",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.feather_esp32s3_reverse_tft.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s3-tft/definition.json
+++ b/boards/feather-esp32s3-tft/definition.json
@@ -6,8 +6,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5483",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-tft-feather",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_feather_esp32s3_tft",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s3",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.feather_esp32s3_tft.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
         "digitalPins":[
           {

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -6,8 +6,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5700",
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-s3",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_qtpy_esp32s3_n4r2",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.qtpy_esp32s3_n4r2.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
         "digitalPins":[
             {


### PR DESCRIPTION
This doesn't yet include the 8mb boards, as they are fine as is, but maybe we want to move them to the esptool method too so we ensure they're running our partition scheme and freshly setup (erased in known state).