### PR TITLE
Migrate 4MB S2 Boards from UF2 to esptool installer

### DIFF
--- a/boards/feather-esp32s2-reverse-tft/definition.json
+++ b/boards/feather-esp32s2-reverse-tft/definition.json
@@ -6,8 +6,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5345",
     "documentationURL":"https://learn.adafruit.com/esp32-s2-reverse-tft-feather",
-    "installMethod": "uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_feather_esp32s2_reverse_tft",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.feather_esp32s2_reverse_tft.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
         "digitalPins":[
           {

--- a/boards/feather-esp32s2-tft/definition.json
+++ b/boards/feather-esp32s2-tft/definition.json
@@ -6,8 +6,20 @@
    "vendor": "Adafruit",
    "productURL": "https://www.adafruit.com/product/5300",
    "documentationURL": "https://learn.adafruit.com/adafruit-esp32-s2-tft-feather",
-   "installMethod": "uf2",
+   "installMethod": "web-native-usb",
    "bootloaderBoardName": "adafruit_feather_esp32s2_tft",
+   "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+         "0x0": "wippersnapper.feather_esp32s2_tft.fatfs.VERSION.combined.bin"
+      }
+   },
    "components": {
       "digitalPins": [
          {

--- a/boards/magtag/definition.json
+++ b/boards/magtag/definition.json
@@ -6,8 +6,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/4800",
     "documentationURL":"https://learn.adafruit.com/adafruit-magtag",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_magtag_29gray",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.magtag.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
        "digitalPins":[
         {

--- a/boards/metroesp32s2/definition.json
+++ b/boards/metroesp32s2/definition.json
@@ -8,7 +8,19 @@
     "productURL":"https://www.adafruit.com/product/4775",
     "documentationURL":"https://learn.adafruit.com/adafruit-metro-esp32-s2",
     "bootloaderBoardName": "adafruit_metro_esp32s2",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.metroesp32s2.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
        "digitalPins":[
           {

--- a/boards/qtpy-esp32s2/definition.json
+++ b/boards/qtpy-esp32s2/definition.json
@@ -6,8 +6,20 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5325",
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-s2",
-    "installMethod":"uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_qtpy_esp32s2",
+    "esptool": {
+      "fileSystemSize": 983040,
+      "blockSize": 4096,
+      "offset": "0x310000",
+      "chip": "esp32s2",
+      "flashMode": "dio",
+      "flashFreq": "80m",
+      "flashSize": "4MB",
+      "structure": {
+        "0x0": "wippersnapper.qtpy_esp32s2.fatfs.VERSION.combined.bin"
+      }
+    },
     "components":{
         "digitalPins":[
             {


### PR DESCRIPTION
Migrates all S2 boards.

I've got no magtag for testing, meaning it is the only one that may go untested.