### PR TITLE
Migrate S3 4MB boards to web-native-usb

### DIFF
--- a/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
+++ b/boards/feather-esp32s3-4mbflash-2mbpsram/definition.json
@@ -6,7 +6,7 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5477",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-feather",
-    "installMethod": "uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_feather_esp32s3",
     "esptool": {
       "fileSystemSize": 983040,

--- a/boards/feather-esp32s3-reverse-tft/definition.json
+++ b/boards/feather-esp32s3-reverse-tft/definition.json
@@ -8,7 +8,7 @@
     "productURL":"https://www.adafruit.com/product/5691",
     "documentationURL": "https://learn.adafruit.com/esp32-s3-reverse-tft-feather",
     "bootloaderBoardName": "adafruit_feather_esp32s3_reverse_tft",
-    "installMethod": "uf2",
+    "installMethod": "web-native-usb",
     "esptool": {
       "fileSystemSize": 983040,
       "blockSize": 4096,

--- a/boards/feather-esp32s3-tft/definition.json
+++ b/boards/feather-esp32s3-tft/definition.json
@@ -6,7 +6,7 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5483",
     "documentationURL":"https://learn.adafruit.com/adafruit-esp32-s3-tft-feather",
-    "installMethod": "uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_feather_esp32s3_tft",
     "esptool": {
       "fileSystemSize": 983040,

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -6,7 +6,7 @@
     "vendor":"Adafruit",
     "productURL":"https://www.adafruit.com/product/5700",
     "documentationURL":"https://learn.adafruit.com/adafruit-qt-py-esp32-s3",
-    "installMethod": "uf2",
+    "installMethod": "web-native-usb",
     "bootloaderBoardName": "adafruit_qtpy_esp32s3_n4r2",
     "esptool": {
       "fileSystemSize": 983040,

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -12,7 +12,7 @@
       "fileSystemSize": 983040,
       "blockSize": 4096,
       "offset": "0x310000",
-      "chip": "esp32s2",
+      "chip": "esp32s3",
       "flashMode": "dio",
       "flashFreq": "80m",
       "flashSize": "4MB",


### PR DESCRIPTION
To merge after release v109, and testing first on staging for updated workflow