### PR TITLE
Update magic_schema.json to have complete visualization object

### DIFF
--- a/boards/magic_schema.json
+++ b/boards/magic_schema.json
@@ -83,14 +83,32 @@
           "minPulseWidth": { "type": "number" },
           "maxPulseWidth": { "type": "number" },
           "visualization": {
+            "description": "Specifies which visual component to use in the WipperSnapper interface and how to configure it",
             "type": "object",
-            "properties": {
-              "offLabel": { "type": "string" },
-              "onLabel": { "type": "string" },
-              "offIcon": { "type": "string" },
-              "onIcon": { "type": "string" }
-            },
-            "additionalProperties": false
+            "discriminator": { "propertyName": "type" },
+            "required": ["type"],
+            "oneOf": [{
+              "properties": {
+                "type": { "const": "switch" },
+                "offLabel": { "type": "string" },
+                "offIcon": { "type": "string" },
+                "onLabel": { "type": "string" },
+                "onIcon": { "type": "string" }
+              },
+              "additionalProperties": false
+            }, {
+              "properties": {
+                "type": { "const": "button" },
+                "pressedLabel": { "type": "string" },
+                "unpressedLabel": { "type": "string" }
+              },
+              "additionalProperties": false
+            }, {
+              "properties": {
+                "type": { "const": "slider" }
+              },
+              "additionalProperties": false
+            }]
           }
         },
         "oneOf": [

--- a/boards/magic_schema.json
+++ b/boards/magic_schema.json
@@ -83,15 +83,15 @@
           "minPulseWidth": { "type": "number" },
           "maxPulseWidth": { "type": "number" },
           "visualization": {
-            "description": "Specifies which visual component to use in the WipperSnapper interface and how to configure it",
+            "description": "Allows overriding the default visualization settings for this component type.",
             "type": "object",
             "properties": {
-                "offLabel": { "type": "string" },
-                "offIcon": { "type": "string" },
-                "onLabel": { "type": "string" },
-                "onIcon": { "type": "string" },
-                "pressedLabel": { "type": "string" },
-                "unpressedLabel": { "type": "string" }
+              "offLabel": { "type": "string" },
+              "offIcon": { "type": "string" },
+              "onLabel": { "type": "string" },
+              "onIcon": { "type": "string" },
+              "pressedLabel": { "type": "string" },
+              "unpressedLabel": { "type": "string" }
             },
             "additionalProperties": false
           }

--- a/boards/magic_schema.json
+++ b/boards/magic_schema.json
@@ -85,30 +85,15 @@
           "visualization": {
             "description": "Specifies which visual component to use in the WipperSnapper interface and how to configure it",
             "type": "object",
-            "discriminator": { "propertyName": "type" },
-            "required": ["type"],
-            "oneOf": [{
-              "properties": {
-                "type": { "const": "switch" },
+            "properties": {
                 "offLabel": { "type": "string" },
                 "offIcon": { "type": "string" },
                 "onLabel": { "type": "string" },
-                "onIcon": { "type": "string" }
-              },
-              "additionalProperties": false
-            }, {
-              "properties": {
-                "type": { "const": "button" },
+                "onIcon": { "type": "string" },
                 "pressedLabel": { "type": "string" },
                 "unpressedLabel": { "type": "string" }
-              },
-              "additionalProperties": false
-            }, {
-              "properties": {
-                "type": { "const": "slider" }
-              },
-              "additionalProperties": false
-            }]
+            },
+            "additionalProperties": false
           }
         },
         "oneOf": [


### PR DESCRIPTION
Updates magic board schema to include full visualisation object from components repo.

https://github.com/adafruit/Wippersnapper_Components/blob/1f7823e15ee49acffb15aab2cc947ea7d1ad6619/components/pin/schema.json#L84-L111
```
  "visualization": {
      "description": "Specifies which visual component to use in the WipperSnapper interface and how to configure it",
      "type": "object",
      "discriminator": { "propertyName": "type" },
      "required": ["type"],
      "oneOf": [{
        "properties": {
          "type": { "const": "switch" },
          "offLabel": { "type": "string" },
          "offIcon": { "type": "string" },
          "onLabel": { "type": "string" },
          "onIcon": { "type": "string" }
        },
        "additionalProperties": false
      }, {
        "properties": {
          "type": { "const": "button" },
          "pressedLabel": { "type": "string" },
          "unpressedLabel": { "type": "string" }
        },
        "additionalProperties": false
      }, {
        "properties": {
          "type": { "const": "slider" }
        },
        "additionalProperties": false
      }]
    }
```


Slightly concerned that the exported did not include the visualisation.type which is in theory mandatory. The magic config import also worked fine without it.
https://github.com/adafruit/Wippersnapper_Boards/blob/5ee7dc9857fc2a6177a299bc432d58318ad13d6c/boards/magtag/magic.json#L76-L80