### PR TITLE
Fix installBoardName formatting in definition.json

### DIFF
--- a/boards/fruitjam/definition.json
+++ b/boards/fruitjam/definition.json
@@ -9,7 +9,7 @@
     "documentationURL":"https://www.adafruit.com/product/6200",
     "published": true,
     "installMethod":"uf2",
-    "installBoardName":"fruitjam_tinyusb",
+    "installBoardName":"fruit_jam_tinyusb",
     "components":{
         "digitalPins":[
             {


### PR DESCRIPTION
Board install is currently broken
<img width="1050" height="124" alt="image" src="https://github.com/user-attachments/assets/68c9d8fb-3bc2-4872-b407-988aa127f4f8" />

Release has extra underscore
<img width="650" height="161" alt="image" src="https://github.com/user-attachments/assets/2773c68b-b317-43e2-9a9a-a719d356b525" />
