### PR TITLE
esp8266 baud rate update

### DIFF
--- a/boards/feather-esp8266/definition.json
+++ b/boards/feather-esp8266/definition.json
@@ -14,7 +14,7 @@
         "baudRate": 115200,
         "fileSystemSize": 2072576,
         "blockSize": 8192,
-        "flashMode" : "qio",
+        "flashMode" : "dio",
         "flashFreq" : "40m",
         "flashSize" : "4MB",
         "structure": {

--- a/boards/feather-esp8266/definition.json
+++ b/boards/feather-esp8266/definition.json
@@ -11,6 +11,7 @@
     "esptool": {
         "offset": "0x200000",
         "chip": "esp8266",
+        "baudRate": 115200,
         "fileSystemSize": 2072576,
         "blockSize": 8192,
         "structure": {

--- a/boards/feather-esp8266/definition.json
+++ b/boards/feather-esp8266/definition.json
@@ -14,6 +14,9 @@
         "baudRate": 115200,
         "fileSystemSize": 2072576,
         "blockSize": 8192,
+        "flashMode" : "qio",
+        "flashFreq" : "40m",
+        "flashSize" : "4MB",
         "structure": {
             "0x0": "wippersnapper.feather_esp8266.littlefs.VERSION.bin"
           }


### PR DESCRIPTION
Currently ESP8266 isn't reporting serial data in v121, so the flash-mode is technically unverified.