### PR TITLE
fix(featherV2): Baud rate 115200bps

### DIFF
--- a/boards/feather-esp32-v2/definition.json
+++ b/boards/feather-esp32-v2/definition.json
@@ -12,6 +12,7 @@
         "blockSize": 4096,
         "offset": "0x670000",
         "chip": "esp32",
+        "baudRate": 115200,
         "flashMode" : "dio",
         "flashFreq" : "80m",
         "flashSize" : "8MB",


### PR DESCRIPTION
Slowing down Comms for Mac M-chips

See https://github.com/adafruit/Adafruit_Wippersnapper_Arduino/issues/856#issuecomment-3764336023