### PR TITLE
Fix I2C address for ADT7410 sensor on PyPortal (original Micro-USB B socket)

### DIFF
--- a/boards/pyportal-tinyusb/magic.json
+++ b/boards/pyportal-tinyusb/magic.json
@@ -39,7 +39,7 @@
       "isI2C": true,
       "type": "adt7410:ambient-temp",
       "period": 30,
-      "i2cAddress": 118,
+      "i2cAddress": 72,
       "sensorType": "ambient-temp"
     },
     {
@@ -47,7 +47,7 @@
       "isI2C": true,
       "type": "adt7410:ambient-temp-fahrenheit",
       "period": 30,
-      "i2cAddress": 118,
+      "i2cAddress": 72,
       "sensorType": "ambient-temp-fahrenheit"
     },
     {


### PR DESCRIPTION
Noticed when testing today that it failed to initialise at 0x76 (i2c scan shows 0x48 and manual add works with that)