### PR TITLE
[ignore] add .claude/settings.local.json and worktree*/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,5 @@ Temporary Items
 .apdisk
 
 # End of https://mrkandreev.name/snippets/gitignore-generator/#macOS
+.claude/settings.local.json
+worktree*/


### PR DESCRIPTION
## Summary
- Ignore `.claude/settings.local.json` (Claude Code local settings)
- Ignore `worktree*/` (local git worktree directories)

## Test plan
- [x] `git status` is clean after creating a `worktree1/` or editing `.claude/settings.local.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)