### PR TITLE
Add second I2C port (STEMMA QT / Wire1) to QT Py boards

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following HDM snippet defines an I2C interface on port 0 with a `SDA` GPIO p
 ],
 ```
 
-Each `i2cPorts` entry may also include an optional `default` boolean (defaults to `false`) marking the port that is enabled/selected by default. If no port is flagged, the default falls back to index ordering (the first entry). Boards with more than one I2C port (for example, a STEMMA QT connector on a second port) should flag the default port explicitly:
+Each `i2cPorts` entry may also include an optional `default` boolean (defaults to `false`) marking the port that is enabled/selected by default. If no port is flagged, the port with the lowest `i2cPortId` is the default. Boards with more than one I2C port (for example, a STEMMA QT connector on a second port) should flag the default port explicitly:
 
 ```
 "i2cPorts": [

--- a/README.md
+++ b/README.md
@@ -73,6 +73,24 @@ The following HDM snippet defines an I2C interface on port 0 with a `SDA` GPIO p
 ],
 ```
 
+Each `i2cPorts` entry may also include an optional `default` boolean (defaults to `true`) marking the port that is enabled/selected by default. Boards with more than one I2C port (for example, a STEMMA QT connector on a second port) should flag the default port explicitly:
+
+```
+"i2cPorts": [
+    {
+        "i2cPortId": 0,
+        "SDA": 41,
+        "SCL": 40
+    },
+    {
+        "i2cPortId": 1,
+        "SDA": 41,
+        "SCL": 40,
+        "default": true
+    }
+],
+```
+
 # Examples
 
 Example hardware descriptions can be found in the `boards/` directory.

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The following HDM snippet defines an I2C interface on port 0 with a `SDA` GPIO p
 ],
 ```
 
-Each `i2cPorts` entry may also include an optional `default` boolean (defaults to `true`) marking the port that is enabled/selected by default. Boards with more than one I2C port (for example, a STEMMA QT connector on a second port) should flag the default port explicitly:
+Each `i2cPorts` entry may also include an optional `default` boolean (defaults to `false`) marking the port that is enabled/selected by default. If no port is flagged, the default falls back to index ordering (the first entry). Boards with more than one I2C port (for example, a STEMMA QT connector on a second port) should flag the default port explicitly:
 
 ```
 "i2cPorts": [

--- a/boards/qtpy-esp32/definition.json
+++ b/boards/qtpy-esp32/definition.json
@@ -172,6 +172,12 @@
                 "i2cPortId":0,
                 "SDA":22,
                 "SCL":19
+            },
+            {
+                "i2cPortId":1,
+                "SDA":22,
+                "SCL":19,
+                "default":true
             }
         ]
     }

--- a/boards/qtpy-esp32s2/definition.json
+++ b/boards/qtpy-esp32s2/definition.json
@@ -176,6 +176,12 @@
                 "i2cPortId":0,
                 "SDA":41,
                 "SCL":40
+            },
+            {
+                "i2cPortId":1,
+                "SDA":41,
+                "SCL":40,
+                "default":true
             }
         ]
     }

--- a/boards/qtpy-esp32s3-n4r2/definition.json
+++ b/boards/qtpy-esp32s3-n4r2/definition.json
@@ -176,6 +176,12 @@
                 "i2cPortId":0,
                 "SDA":41,
                 "SCL":40
+            },
+            {
+                "i2cPortId":1,
+                "SDA":41,
+                "SCL":40,
+                "default":true
             }
         ]
     }

--- a/boards/qtpy-esp32s3/definition.json
+++ b/boards/qtpy-esp32s3/definition.json
@@ -164,6 +164,12 @@
                 "i2cPortId":0,
                 "SDA":41,
                 "SCL":40
+            },
+            {
+                "i2cPortId":1,
+                "SDA":41,
+                "SCL":40,
+                "default":true
             }
         ]
     }

--- a/boards/schema.json
+++ b/boards/schema.json
@@ -183,7 +183,7 @@
               "SDA": { "type": "number" },
               "SCL": { "type": "number" },
               "default": {
-                "description": "Whether this I2C port is enabled/selected by default. Optional; defaults to false. If no port is flagged, the default falls back to index ordering (the first entry).",
+                "description": "Whether this I2C port is enabled/selected by default. Optional; defaults to false. If no port is flagged, the port with the lowest i2cPortId is the default.",
                 "type": "boolean",
                 "default": false
               }

--- a/boards/schema.json
+++ b/boards/schema.json
@@ -183,9 +183,9 @@
               "SDA": { "type": "number" },
               "SCL": { "type": "number" },
               "default": {
-                "description": "Whether this I2C port is enabled/selected by default. Optional; defaults to true.",
+                "description": "Whether this I2C port is enabled/selected by default. Optional; defaults to false. If no port is flagged, the default falls back to index ordering (the first entry).",
                 "type": "boolean",
-                "default": true
+                "default": false
               }
             }
           }

--- a/boards/schema.json
+++ b/boards/schema.json
@@ -181,7 +181,12 @@
             "properties": {
               "i2cPortId": { "type": "number" },
               "SDA": { "type": "number" },
-              "SCL": { "type": "number" }
+              "SCL": { "type": "number" },
+              "default": {
+                "description": "Whether this I2C port is enabled/selected by default. Optional; defaults to true.",
+                "type": "boolean",
+                "default": true
+              }
             }
           }
         }


### PR DESCRIPTION
### Overview

The QT Py family exposes a STEMMA QT connector wired to a second logical I2C port (Wire1). This adds a second `i2cPort` (id 1) matching the STEMMA QT pins, flagged as the default port, on the four QT Py boards whose `I2C_STEMMA_WIRE1` defines were fixed in adafruit/Adafruit_Wippersnapper_Arduino#935:

- **qtpy-esp32s3** — GPIO41 SDA / GPIO40 SCL
- **qtpy-esp32s3-n4r2** — GPIO41 SDA / GPIO40 SCL
- **qtpy-esp32s2** — GPIO41 SDA / GPIO40 SCL
- **qtpy-esp32** (Pico) — GPIO22 SDA / GPIO19 SCL

Pin assignments match the `SDA1`/`SCL1` values in each board's arduino-esp32 variant. This mirrors the two-port layout used by boards like [`esp32c5-devkitc-1-n8r4`](https://github.com/adafruit/Wippersnapper_Boards/blob/api-v2/boards/esp32c5-devkitc-1-n8r4/definition.json).

### Schema

Adds an optional `default` boolean to `i2cPorts` items so a port can be flagged as the default-selected port. It defaults to `false`; when no port is flagged, the port with the lowest `i2cPortId` is the default. The field is optional and `additionalProperties` stays `false`, so all existing single-port board definitions remain valid.

```json
"i2cPorts": [
  { "i2cPortId": 0, "SDA": 41, "SCL": 40 },
  { "i2cPortId": 1, "SDA": 41, "SCL": 40, "default": true }
]
```

The new field is also documented in the README's I2C Components section.

All board definitions validate against the updated schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
